### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/pixabay_api.dart
+++ b/lib/pixabay_api.dart
@@ -108,7 +108,7 @@ class PixabayImageProvider {
     if (response.statusCode == 200) {
       // response: OK
       // decode JSON
-      String json = await response.transform(utf8.decoder).join();
+      String json = await utf8.decoder.bind(response).join();
       var data = jsonDecode(json);
       return data;
     } else {
@@ -127,7 +127,7 @@ class PixabayImageProvider {
     if (response.statusCode == 200) {
       // response: OK
       // decode JSON
-      String json = await response.transform(utf8.decoder).join();
+      String json = await utf8.decoder.bind(response).join();
       var data = jsonDecode(json);
       return data;
     } else {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
